### PR TITLE
Conan lock for boost

### DIFF
--- a/conan.lock
+++ b/conan.lock
@@ -1,0 +1,11 @@
+{
+    "version": "0.5",
+    "requires": [
+        "boost/1.87.0#53c53f3d6eeb9db4a3d68573596db0e7%1741105890.981"
+    ],
+    "build_requires": [
+        "b2/5.2.1#91bc73931a0acb655947a81569ed8b80%1718416612.241"
+    ],
+    "python_requires": [],
+    "config_requires": []
+}


### PR DESCRIPTION
Adding conan lock due to boost failing to build on github action runners using newer versions of b2