### PR TITLE
Use git commit hash for fetching pybind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.13)
+  GIT_TAG a2e59f0e7065404b44dfe92a28aca47ba1378dc4) # v2.13
 FetchContent_MakeAvailable(pybind11)
 
 FetchContent_Declare(


### PR DESCRIPTION
Using a git tag could lead to getting a different version than intended if the owner of the repo decides to point the tag at a new commit.