### PR TITLE
Rename nx to ncol and ny to nrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import surfio
 
 
 surface = surfio.IrapSurface.import_ascii_file("./file.irap")
-print(surface.header.nx, surface.header.ny) # 10, 11
+print(surface.header.ncol, surface.header.nrow) # 10, 11
 print(surface.values.shape) # (10, 11)
 ```
 
@@ -35,8 +35,8 @@ Exporting irap surfaces can be done with
 ```python
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=3,
-            ny=2,
+            ncol=3,
+            nrow=2,
             xori=0.0,
             yori=0.0,
             xinc=2.0,

--- a/src/lib/include/irap.h
+++ b/src/lib/include/irap.h
@@ -5,14 +5,14 @@ constexpr float UNDEF_MAP_IRAP = 9999900.0000;
 
 struct irap_header {
   static constexpr int id = -996;
-  int ny;
+  int nrow;
   double xori;
   double xmax;
   double yori;
   double ymax;
   double xinc;
   double yinc;
-  int nx;
+  int ncol;
   double rot;
   double xrot;
   double yrot;

--- a/src/lib/irap_export_ascii.cpp
+++ b/src/lib/irap_export_ascii.cpp
@@ -13,9 +13,9 @@ static auto UNDEF_MAP_IRAP_STRING = std::format("{:f}", UNDEF_MAP_IRAP);
 
 void write_header_ascii(const irap_header& header, std::ostream& out) {
   out << std::setprecision(6) << std::fixed << std::showpoint;
-  out << id << header.ny << " " << header.xinc << " " << header.yinc << "\n";
+  out << id << header.nrow << " " << header.xinc << " " << header.yinc << "\n";
   out << header.xori << " " << header.xmax << " " << header.yori << " " << header.ymax << "\n";
-  out << header.nx << " " << header.rot << " " << header.xrot << " " << header.yrot << "\n";
+  out << header.ncol << " " << header.rot << " " << header.xrot << " " << header.yrot << "\n";
   out << "0 0 0 0 0 0 0\n";
 }
 
@@ -45,7 +45,7 @@ void export_irap_to_ascii_file(
 
 void export_irap_to_ascii_file(const std::string& filename, const irap& data) {
   export_irap_to_ascii_file(
-      filename, data.header, surf_span{data.values.data(), data.header.nx, data.header.ny}
+      filename, data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
   );
 }
 
@@ -58,6 +58,6 @@ std::string export_irap_to_ascii_string(const irap_header& header, surf_span val
 
 std::string export_irap_to_ascii_string(const irap& data) {
   return export_irap_to_ascii_string(
-      data.header, surf_span{data.values.data(), data.header.nx, data.header.ny}
+      data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
   );
 }

--- a/src/lib/irap_export_binary.cpp
+++ b/src/lib/irap_export_binary.cpp
@@ -24,8 +24,8 @@ void write_32bit_binary_values(std::ostream& out, T&&... values) {
 
 void write_header_binary(const irap_header& header, std::ostream& out) {
   write_32bit_binary_values(
-      out, 32, irap_header::id, header.ny, header.xori, header.xmax, header.yori, header.ymax,
-      header.xinc, header.yinc, 32, 16, header.nx, header.rot, header.xrot, header.yrot, 16, 28,
+      out, 32, irap_header::id, header.nrow, header.xori, header.xmax, header.yori, header.ymax,
+      header.xinc, header.yinc, 32, 16, header.ncol, header.rot, header.xrot, header.yrot, 16, 28,
       0.f, 0.f, 0, 0, 0, 0, 0, 28
   );
 }
@@ -64,7 +64,7 @@ void export_irap_to_binary_file(
 
 void export_irap_to_binary_file(const std::string& filename, const irap& data) {
   export_irap_to_binary_file(
-      filename, data.header, surf_span{data.values.data(), data.header.nx, data.header.ny}
+      filename, data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
   );
 }
 
@@ -77,6 +77,6 @@ std::string export_irap_to_binary_string(const irap_header& header, surf_span va
 
 std::string export_irap_to_binary_string(const irap& data) {
   return export_irap_to_binary_string(
-      data.header, surf_span{data.values.data(), data.header.nx, data.header.ny}
+      data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
   );
 }

--- a/src/pybind_module/surfio.cpp
+++ b/src/pybind_module/surfio.cpp
@@ -12,7 +12,7 @@ irap_python* make_irap_python(const irap& data) {
   constexpr auto size = sizeof(decltype(irap::values)::value_type);
   return new irap_python{
       data.header,
-      {{data.header.nx, data.header.ny}, {size * data.header.ny, size}, data.values.data()}
+      {{data.header.ncol, data.header.nrow}, {size * data.header.nrow, size}, data.values.data()}
   };
 }
 
@@ -25,17 +25,17 @@ PYBIND11_MODULE(surfio, m) {
       .def(
           py::init<
               int, double, double, double, double, double, double, int, double, double, double>(),
-          py::arg("ny"), py::arg("xori"), py::arg("xmax"), py::arg("yori"), py::arg("ymax"),
-          py::arg("xinc"), py::arg("yinc"), py::arg("nx"), py::arg("rot"), py::arg("xrot"),
+          py::arg("nrow"), py::arg("xori"), py::arg("xmax"), py::arg("yori"), py::arg("ymax"),
+          py::arg("xinc"), py::arg("yinc"), py::arg("ncol"), py::arg("rot"), py::arg("xrot"),
           py::arg("yrot")
       )
       .def(
           "__repr__",
           [](const irap_header& header) {
             return std::format(
-                "<IrapHeader(nx={}, ny={}, xory={}, yori={}, xinc={}, yinc={}, xmax={}, ymax={}, "
-                "rot={}, xrot={}, yrot={})>",
-                header.nx, header.ny, header.xori, header.yori, header.xinc, header.yinc,
+                "<IrapHeader(ncol={}, nrow={}, xory={}, yori={}, xinc={}, yinc={}, xmax={}, "
+                "ymax={}, rot={}, xrot={}, yrot={})>",
+                header.ncol, header.nrow, header.xori, header.yori, header.xinc, header.yinc,
                 header.xmax, header.ymax, header.rot, header.xrot, header.yrot
             );
           }
@@ -52,8 +52,8 @@ PYBIND11_MODULE(surfio, m) {
       .def_readwrite("ymax", &irap_header::ymax)
       .def_readwrite("xrot", &irap_header::xrot)
       .def_readwrite("yrot", &irap_header::yrot)
-      .def_readwrite("nx", &irap_header::nx)
-      .def_readwrite("ny", &irap_header::ny);
+      .def_readwrite("ncol", &irap_header::ncol)
+      .def_readwrite("nrow", &irap_header::nrow);
 
   py::class_<irap_python>(m, "IrapSurface")
       .def(py::init<irap_header, py::array_t<float>>(), py::arg("header"), py::arg("values"))
@@ -61,9 +61,9 @@ PYBIND11_MODULE(surfio, m) {
           "__repr__",
           [](const irap_python& ip) {
             return std::format(
-                "<IrapSurface(header=IrapHeader(nx={}, ny={}, xory={}, yori={}, xinc={}, yinc={}, "
-                "xmax={}, ymax={}, rot={}, xrot={}, yrot={}), values=...)>",
-                ip.header.nx, ip.header.ny, ip.header.xori, ip.header.yori, ip.header.xinc,
+                "<IrapSurface(header=IrapHeader(ncol={}, nrow={}, xory={}, yori={}, xinc={}, "
+                "yinc={}, xmax={}, ymax={}, rot={}, xrot={}, yrot={}), values=...)>",
+                ip.header.ncol, ip.header.nrow, ip.header.xori, ip.header.yori, ip.header.xinc,
                 ip.header.yinc, ip.header.xmax, ip.header.ymax, ip.header.rot, ip.header.xrot,
                 ip.header.yrot
             );

--- a/tests/lib/test_irap_ascii.cpp
+++ b/tests/lib/test_irap_ascii.cpp
@@ -8,19 +8,19 @@
 
 SCENARIO("Verify that surfio can read and write irap ascii files", "[test_irap_ascii.cpp]") {
   auto _header = irap_header{
-      .ny = 6000,
+      .nrow = 6000,
       .xori = 0.,
       .xmax = 0,
       .yori = 0.,
       .ymax = 0.,
       .xinc = 0,
       .yinc = 0.,
-      .nx = 6000,
+      .ncol = 6000,
       .rot = 0.,
       .xrot = 0.,
       .yrot = 0.
   };
-  auto _values = std::vector<float>(_header.nx * _header.ny);
+  auto _values = std::vector<float>(_header.ncol * _header.nrow);
   std::mt19937 g;
   std::uniform_real_distribution<> u;
   std::generate(_values.begin(), _values.end(), [&]() { return u(g); });

--- a/tests/lib/test_irap_binary.cpp
+++ b/tests/lib/test_irap_binary.cpp
@@ -8,19 +8,19 @@
 
 SCENARIO("Verify that surfio can read and write irap binary files", "[test_irap_binary.cpp]") {
   auto _header = irap_header{
-      .ny = 6000,
+      .nrow = 6000,
       .xori = 0.,
       .xmax = 0,
       .yori = 0.,
       .ymax = 0.,
       .xinc = 0,
       .yinc = 0.,
-      .nx = 6000,
+      .ncol = 6000,
       .rot = 0.,
       .xrot = 0.,
       .yrot = 0.
   };
-  auto _values = std::vector<float>(_header.nx * _header.ny);
+  auto _values = std::vector<float>(_header.ncol * _header.nrow);
   std::mt19937 g;
   std::uniform_real_distribution<> u;
   std::generate(_values.begin(), _values.end(), [&]() { return u(g); });

--- a/tests/python_module/test_irap_ascii.py
+++ b/tests/python_module/test_irap_ascii.py
@@ -7,8 +7,8 @@ import surfio
 def test_irap_surface_string_representation(func):
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=3,
-            ny=2,
+            ncol=3,
+            nrow=2,
             xori=0.0,
             yori=0.0,
             xinc=2.0,
@@ -22,7 +22,8 @@ def test_irap_surface_string_representation(func):
         values=np.zeros((3, 2)),
     )
     assert (
-        func(surface) == "<IrapSurface(header=IrapHeader(nx=3, ny=2, xory=0, yori=0,"
+        func(surface)
+        == "<IrapSurface(header=IrapHeader(ncol=3, nrow=2, xory=0, yori=0,"
         " xinc=2, yinc=2, xmax=2, ymax=2, rot=0, xrot=0, yrot=0), values=...)>"
     )
 
@@ -177,8 +178,8 @@ def test_header_can_have_high_precision():
 def test_import_and_export_are_inverse():
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=3,
-            ny=2,
+            ncol=3,
+            nrow=2,
             xori=0.0,
             yori=0.0,
             xinc=2.0,
@@ -200,8 +201,8 @@ def test_import_and_export_file_are_inverse(tmp_path):
     irap_path = tmp_path / "test.irap"
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=3,
-            ny=2,
+            ncol=3,
+            nrow=2,
             xori=0.0,
             yori=0.0,
             xinc=2.0,
@@ -223,8 +224,8 @@ def test_import_and_export_file_are_inverse(tmp_path):
 def test_exporting_nan_maps_to_9999900():
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=1,
-            ny=1,
+            ncol=1,
+            nrow=1,
             xori=0.0,
             yori=0.0,
             xinc=2.0,
@@ -247,8 +248,8 @@ def test_exporting_produces_max_9_values_per_line():
     """
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=10,
-            ny=1,
+            ncol=10,
+            nrow=1,
             xori=0.0,
             yori=0.0,
             xinc=2.0,

--- a/tests/python_module/test_irap_binary.py
+++ b/tests/python_module/test_irap_binary.py
@@ -10,8 +10,8 @@ import xtgeo
 def compare_xtgeo_surface_with_surfio_header(
     xtgeo_surface: xtgeo.RegularSurface, surfio_header: surfio.IrapHeader
 ):
-    assert xtgeo_surface.ncol == surfio_header.nx
-    assert xtgeo_surface.nrow == surfio_header.ny
+    assert xtgeo_surface.ncol == surfio_header.ncol
+    assert xtgeo_surface.nrow == surfio_header.nrow
     assert xtgeo_surface.xori == surfio_header.xori
     assert xtgeo_surface.yori == surfio_header.yori
     assert xtgeo_surface.xinc == surfio_header.xinc
@@ -54,8 +54,8 @@ def test_binary_xtgeo_is_imported_correctly_in_surfio():
 def test_surfio_can_import_data_exported_from_surfio():
     srf = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=3,
-            ny=2,
+            ncol=3,
+            nrow=2,
             xori=0.0,
             yori=0.0,
             xinc=1.0,
@@ -78,8 +78,8 @@ def test_surfio_can_import_data_exported_from_surfio():
 def test_xtgeo_can_import_data_exported_from_surfio(tmp_path):
     srf = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=3,
-            ny=2,
+            ncol=3,
+            nrow=2,
             xori=0.0,
             yori=0.0,
             xinc=1.0,
@@ -102,8 +102,8 @@ def test_xtgeo_can_import_data_exported_from_surfio(tmp_path):
 def test_exporting_nan_maps_to_9999900():
     surface = surfio.IrapSurface(
         surfio.IrapHeader(
-            nx=1,
-            ny=1,
+            ncol=1,
+            nrow=1,
             xori=0.0,
             yori=0.0,
             xinc=2.0,


### PR DESCRIPTION
Due to irap being in cartesian coordinates the x axis corresponds to columns unlike in matrices. 
Following how xtgeo handles this by using cols/rows instead of x/y.
Another reason to use cols/rows is that the matrix does not represent real coordinates as the matrix may be rotatated/flipped