### PR TITLE
Add info about C++ development in readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,5 +83,6 @@ set(SRC_PATH "${CMAKE_CURRENT_LIST_DIR}/tests/lib")
 add_executable(tests ${SRC_PATH}/test_irap_ascii.cpp ${SRC_PATH}/test_irap_binary.cpp)
 
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain surfio_lib)
+include(CTest)
 include(Catch)
 catch_discover_tests(tests)

--- a/README.md
+++ b/README.md
@@ -70,3 +70,23 @@ Style is enforced via pre-commit:
 ```bash
 pre-commit install
 ```
+
+## C++ development
+
+To configure the project
+
+```bash
+cmake --preset release-posix
+```
+
+To build it
+
+```bash
+cmake --build --preset release-posix
+```
+
+To test it
+
+```bash
+ctest --preset release-posix
+```


### PR DESCRIPTION
Also added include(CTest) so that we can run `ctest --preset=test-posix` for c++ testing