### PR TITLE
Use std::filesystem::path for paths

### DIFF
--- a/src/lib/include/irap_export.h
+++ b/src/lib/include/irap_export.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "irap.h"
+#include <filesystem>
 #include <ostream>
 
 #if __cpp_lib_mdspan
@@ -28,17 +29,17 @@ void write_header_binary(const irap_header& header, std::ostream& out);
 void write_values_binary(surf_span values, std::ostream& out);
 
 void export_irap_to_ascii_file(
-    const std::string& filename, const irap_header& header, surf_span values
+    const std::filesystem::path& file, const irap_header& header, surf_span values
 );
-void export_irap_to_ascii_file(const std::string& filename, const irap& data);
+void export_irap_to_ascii_file(const std::filesystem::path& file, const irap& data);
 
 std::string export_irap_to_ascii_string(const irap_header& header, surf_span values);
 std::string export_irap_to_ascii_string(const irap& data);
 
 void export_irap_to_binary_file(
-    const std::string& filename, const irap_header& header, surf_span values
+    const std::filesystem::path& file, const irap_header& header, surf_span values
 );
-void export_irap_to_binary_file(const std::string& filename, const irap& data);
+void export_irap_to_binary_file(const std::filesystem::path& file, const irap& data);
 
 std::string export_irap_to_binary_string(const irap_header& header, surf_span values);
 std::string export_irap_to_binary_string(const irap& data);

--- a/src/lib/include/irap_import.h
+++ b/src/lib/include/irap_import.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "irap.h"
+#include <filesystem>
 #include <span>
-#include <string>
 #include <string_view>
 
 // convert from Fortran order to C order
@@ -10,7 +10,7 @@ inline size_t column_major_to_row_major_index(size_t idx, size_t nrow, size_t nc
   return idx / nrow + (idx % nrow) * ncol;
 }
 
-irap import_irap_ascii(std::string path);
+irap import_irap_ascii(const std::filesystem::path& file);
 irap import_irap_ascii_from_string(std::string_view buffer);
-irap import_irap_binary(std::string path);
+irap import_irap_binary(const std::filesystem::path& file);
 irap import_irap_binary_from_buffer(std::span<const char> buffer);

--- a/src/lib/irap_export_ascii.cpp
+++ b/src/lib/irap_export_ascii.cpp
@@ -1,11 +1,14 @@
 #include "include/irap.h"
 #include "include/irap_export.h"
 #include <cmath>
+#include <filesystem>
 #include <format>
 #include <fstream>
 #include <iomanip>
 #include <ostream>
 #include <sstream>
+
+namespace fs = std::filesystem;
 
 // All irap headers start with -996
 static const auto id = std::format("{} ", irap_header::id);
@@ -35,17 +38,15 @@ void write_values_ascii(surf_span values, std::ostream& out) {
   }
 }
 
-void export_irap_to_ascii_file(
-    const std::string& filename, const irap_header& header, surf_span values
-) {
-  std::ofstream out(filename);
+void export_irap_to_ascii_file(const fs::path& file, const irap_header& header, surf_span values) {
+  std::ofstream out(file);
   write_header_ascii(header, out);
   write_values_ascii(values, out);
 }
 
-void export_irap_to_ascii_file(const std::string& filename, const irap& data) {
+void export_irap_to_ascii_file(const fs::path& file, const irap& data) {
   export_irap_to_ascii_file(
-      filename, data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
+      file, data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
   );
 }
 

--- a/src/lib/irap_export_binary.cpp
+++ b/src/lib/irap_export_binary.cpp
@@ -5,9 +5,11 @@
 #include <bit>
 #include <cmath>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
-#include <memory>
 #include <sstream>
+
+namespace fs = std::filesystem;
 
 template <IsLittleEndianNumeric T> void write_32bit_binary_value(char*& bufptr, T&& value) {
   std::array<char, 4> tmp;
@@ -74,17 +76,15 @@ void write_values_binary(surf_span values, std::ostream& out) {
     out.write(buf, dist);
 }
 
-void export_irap_to_binary_file(
-    const std::string& filename, const irap_header& header, surf_span values
-) {
-  std::ofstream out(filename, std::ios::binary);
+void export_irap_to_binary_file(const fs::path& file, const irap_header& header, surf_span values) {
+  std::ofstream out(file, std::ios::binary);
   write_header_binary(header, out);
   write_values_binary(values, out);
 }
 
-void export_irap_to_binary_file(const std::string& filename, const irap& data) {
+void export_irap_to_binary_file(const fs::path& file, const irap& data) {
   export_irap_to_binary_file(
-      filename, data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
+      file, data.header, surf_span{data.values.data(), data.header.ncol, data.header.nrow}
   );
 }
 

--- a/src/lib/irap_import_ascii.cpp
+++ b/src/lib/irap_import_ascii.cpp
@@ -2,7 +2,10 @@
 #include "mmap_wrapper/mmap_wrapper.h"
 #include <algorithm>
 #include <charconv>
+#include <filesystem>
 #include <format>
+
+namespace fs = std::filesystem;
 
 auto locale = std::locale("C");
 auto& facet = std::use_facet<std::ctype<char>>(locale);
@@ -78,8 +81,8 @@ std::vector<float> get_values(const char* start, const char* end, int ncol, int 
   return values;
 }
 
-irap import_irap_ascii(std::string path) {
-  auto buffer = mmap_file(path);
+irap import_irap_ascii(const fs::path& file) {
+  auto buffer = mmap_file(file);
 
   auto [head, ptr] = get_header(buffer.begin(), buffer.end());
   auto values = get_values(ptr, buffer.end(), head.ncol, head.nrow);

--- a/src/lib/irap_import_binary.cpp
+++ b/src/lib/irap_import_binary.cpp
@@ -5,10 +5,13 @@
 #include <array>
 #include <bit>
 #include <cstdint>
+#include <filesystem>
 #include <format>
 #include <ranges>
 #include <span>
 #include <stdexcept>
+
+namespace fs = std::filesystem;
 
 template <typename T> T swap_byte_order(const T& value) {
   auto tmp = std::bit_cast<std::array<std::byte, sizeof(T)>>(value);
@@ -103,8 +106,8 @@ std::vector<float> get_values_binary(const char* start, const char* end, int nco
   return values;
 }
 
-irap import_irap_binary(std::string path) {
-  auto buffer = mmap_file(path);
+irap import_irap_binary(const fs::path& file) {
+  auto buffer = mmap_file(file);
   auto [header, ptr] = get_header_binary(buffer);
   auto values = get_values_binary(ptr, buffer.end(), header.ncol, header.nrow);
 

--- a/src/lib/mmap_wrapper/mmap_wrapper.cpp
+++ b/src/lib/mmap_wrapper/mmap_wrapper.cpp
@@ -3,16 +3,18 @@
 #include <format>
 #include <stdexcept>
 
+namespace fs = std::filesystem;
+
 struct internals {
   mio::mmap_source handle;
 };
 
-mmap_file::mmap_file(const std::string& filename) {
+mmap_file::mmap_file(const fs::path& file) {
   std::error_code ec;
-  auto handle = mio::make_mmap_source(filename, ec);
+  auto handle = mio::make_mmap_source(file.string(), ec);
   if (ec)
     throw std::runtime_error(
-        std::format("failed to map file :{}, with error: {}", filename, ec.message())
+        std::format("failed to map file :{}, with error: {}", file.string(), ec.message())
     );
 
   d = std::make_unique<internals>(std::move(handle));

--- a/src/lib/mmap_wrapper/mmap_wrapper.h
+++ b/src/lib/mmap_wrapper/mmap_wrapper.h
@@ -1,13 +1,11 @@
-#pragma once
-
+#include <filesystem>
 #include <memory>
-#include <string>
 
 struct internals;
 
 class mmap_file {
 public:
-  mmap_file(const std::string& filename);
+  mmap_file(const std::filesystem::path& file);
   ~mmap_file();
   const char* begin() const;
   const char* end() const;

--- a/src/pybind_module/surfio.cpp
+++ b/src/pybind_module/surfio.cpp
@@ -1,6 +1,7 @@
 #include "include/irap_pybind.h"
 #include "irap_export.h"
 #include "irap_import.h"
+#include <filesystem>
 #include <format>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
@@ -9,6 +10,7 @@
 #include <string_view>
 
 namespace py = pybind11;
+namespace fs = std::filesystem;
 
 irap_python* make_irap_python(const irap& data) {
   constexpr auto size = sizeof(decltype(irap::values)::value_type);
@@ -78,8 +80,8 @@ PYBIND11_MODULE(surfio, m) {
       .def_readwrite("values", &irap_python::values)
       .def_static(
           "import_ascii_file",
-          [](const std::string& path) -> irap_python* {
-            auto irap = import_irap_ascii(path);
+          [](fs::path file) -> irap_python* {
+            auto irap = import_irap_ascii(file);
             // lock the GIL before creating the numpy array
             py::gil_scoped_acquire acquire;
             return make_irap_python(irap);
@@ -98,8 +100,8 @@ PYBIND11_MODULE(surfio, m) {
       )
       .def_static(
           "import_binary_file",
-          [](const std::string& path) -> irap_python* {
-            auto irap = import_irap_binary(path);
+          [](fs::path file) -> irap_python* {
+            auto irap = import_irap_binary(file);
             // lock the GIL before creating the numpy array
             py::gil_scoped_acquire acquire;
             return make_irap_python(irap);
@@ -124,8 +126,8 @@ PYBIND11_MODULE(surfio, m) {
       )
       .def(
           "export_ascii_file",
-          [](const irap_python& ip, const std::string& filename) -> void {
-            export_irap_to_ascii_file(filename, ip.header, make_surf_span(ip));
+          [](const irap_python& ip, fs::path file) -> void {
+            export_irap_to_ascii_file(file, ip.header, make_surf_span(ip));
           }
       )
       .def(
@@ -135,7 +137,7 @@ PYBIND11_MODULE(surfio, m) {
             return py::bytes(buffer);
           }
       )
-      .def("export_binary_file", [](const irap_python& ip, const std::string& filename) -> void {
-        export_irap_to_binary_file(filename, ip.header, make_surf_span(ip));
+      .def("export_binary_file", [](const irap_python& ip, fs::path file) -> void {
+        export_irap_to_binary_file(file, ip.header, make_surf_span(ip));
       });
 }

--- a/tests/lib/test_irap_ascii.cpp
+++ b/tests/lib/test_irap_ascii.cpp
@@ -11,7 +11,7 @@ using namespace Catch;
 namespace fs = std::filesystem;
 
 SCENARIO("Verify that surfio can read and write irap ascii files", "[test_irap_ascii.cpp]") {
-  const std::string filename("surf.irap");
+  fs::path filename("surf.irap");
   auto header = irap_header{
       .ncol = 6000,
       .nrow = 6000,

--- a/tests/lib/test_irap_binary.cpp
+++ b/tests/lib/test_irap_binary.cpp
@@ -11,7 +11,7 @@ using namespace Catch;
 namespace fs = std::filesystem;
 
 SCENARIO("Verify that surfio can read and write irap binary files", "[test_irap_binary.cpp]") {
-  const std::string filename("surf.irap");
+  fs::path filename("surf.irap");
   auto header = irap_header{
       .ncol = 6000,
       .nrow = 6000,


### PR DESCRIPTION
This allows pybind to use both Pathlib.Path and strings as input