### PR TITLE
Fix fortran order bug

### DIFF
--- a/src/pybind_module/surfio.cpp
+++ b/src/pybind_module/surfio.cpp
@@ -57,7 +57,10 @@ PYBIND11_MODULE(surfio, m) {
       .def_readwrite("yrot", &irap_header::yrot);
 
   py::class_<irap_python>(m, "IrapSurface")
-      .def(py::init<irap_header, py::array_t<float>>(), py::arg("header"), py::arg("values"))
+      .def(
+          py::init<irap_header, py::array_t<float, py::array::c_style | py::array::forcecast>>(),
+          py::arg("header"), py::arg("values")
+      )
       .def(
           "__repr__",
           [](const irap_python& ip) {

--- a/tests/python_module/test_irap_ascii.py
+++ b/tests/python_module/test_irap_ascii.py
@@ -6,19 +6,7 @@ import surfio
 @pytest.mark.parametrize("func", [str, repr])
 def test_irap_surface_string_representation(func):
     surface = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=3,
-            nrow=2,
-            xori=0.0,
-            yori=0.0,
-            xinc=2.0,
-            yinc=2.0,
-            xmax=2.0,
-            ymax=2.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.zeros((3, 2)),
     )
     assert (
@@ -177,19 +165,7 @@ def test_header_can_have_high_precision():
 
 def test_import_and_export_are_inverse():
     surface = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=3,
-            nrow=2,
-            xori=0.0,
-            yori=0.0,
-            xinc=2.0,
-            yinc=2.0,
-            xmax=2.0,
-            ymax=2.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.arange(6, dtype=np.float32).reshape((3, 2)),
     )
     roundtrip = surfio.IrapSurface.import_ascii(surface.export_ascii())
@@ -200,19 +176,7 @@ def test_import_and_export_are_inverse():
 def test_import_and_export_file_are_inverse(tmp_path):
     irap_path = tmp_path / "test.irap"
     surface = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=3,
-            nrow=2,
-            xori=0.0,
-            yori=0.0,
-            xinc=2.0,
-            yinc=2.0,
-            xmax=2.0,
-            ymax=2.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.arange(6, dtype=np.float32).reshape((3, 2)),
     )
     surface.export_ascii_file(str(irap_path))
@@ -223,19 +187,7 @@ def test_import_and_export_file_are_inverse(tmp_path):
 
 def test_exporting_nan_maps_to_9999900():
     surface = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=1,
-            nrow=1,
-            xori=0.0,
-            yori=0.0,
-            xinc=2.0,
-            yinc=2.0,
-            xmax=2.0,
-            ymax=2.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=1, nrow=1, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.array([[np.nan]], dtype=np.float32),
     )
 
@@ -247,19 +199,7 @@ def test_exporting_produces_max_9_values_per_line():
     This is the maximum supported by some applications
     """
     surface = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=10,
-            nrow=1,
-            xori=0.0,
-            yori=0.0,
-            xinc=2.0,
-            yinc=2.0,
-            xmax=2.0,
-            ymax=2.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=10, nrow=1, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.zeros((10, 1), dtype=np.float32),
     )
 

--- a/tests/python_module/test_irap_ascii.py
+++ b/tests/python_module/test_irap_ascii.py
@@ -264,3 +264,15 @@ def test_exporting_produces_max_9_values_per_line():
     )
 
     assert all(len(line.split()) <= 9 for line in surface.export_ascii().splitlines())
+
+
+def test_surfio_can_export_values_in_fortran_order():
+    srf = surfio.IrapSurface(
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=1.0, yinc=1.0, xmax=8.0, ymax=8.0),
+        values=np.asfortranarray(np.arange(6, dtype=np.float32).reshape((3, 2))),
+    )
+    buffer = srf.export_ascii()
+    srf_imported = surfio.IrapSurface.import_ascii(buffer)
+
+    assert np.allclose(srf.values, srf_imported.values)
+    assert srf.header == srf_imported.header

--- a/tests/python_module/test_irap_binary.py
+++ b/tests/python_module/test_irap_binary.py
@@ -53,19 +53,7 @@ def test_binary_xtgeo_is_imported_correctly_in_surfio():
 
 def test_surfio_can_import_data_exported_from_surfio():
     srf = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=3,
-            nrow=2,
-            xori=0.0,
-            yori=0.0,
-            xinc=1.0,
-            yinc=1.0,
-            xmax=8.0,
-            ymax=8.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=1.0, yinc=1.0, xmax=8.0, ymax=8.0),
         values=np.arange(6, dtype=np.float32).reshape((3, 2)),
     )
     buffer = srf.export_binary()
@@ -89,19 +77,7 @@ def test_surfio_can_export_values_in_fortran_order():
 
 def test_xtgeo_can_import_data_exported_from_surfio(tmp_path):
     srf = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=3,
-            nrow=2,
-            xori=0.0,
-            yori=0.0,
-            xinc=1.0,
-            yinc=1.0,
-            xmax=8.0,
-            ymax=8.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=1.0, yinc=1.0, xmax=8.0, ymax=8.0),
         values=np.arange(6, dtype=np.float32).reshape((3, 2)),
     )
     srf.export_binary_file(str(tmp_path / "test.irap"))
@@ -113,19 +89,7 @@ def test_xtgeo_can_import_data_exported_from_surfio(tmp_path):
 
 def test_exporting_nan_maps_to_9999900():
     surface = surfio.IrapSurface(
-        surfio.IrapHeader(
-            ncol=1,
-            nrow=1,
-            xori=0.0,
-            yori=0.0,
-            xinc=2.0,
-            yinc=2.0,
-            xmax=2.0,
-            ymax=2.0,
-            rot=0.0,
-            xrot=0.0,
-            yrot=0.0,
-        ),
+        surfio.IrapHeader(ncol=1, nrow=1, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.array([[np.nan]], dtype=np.float32),
     )
 

--- a/tests/python_module/test_irap_binary.py
+++ b/tests/python_module/test_irap_binary.py
@@ -75,6 +75,18 @@ def test_surfio_can_import_data_exported_from_surfio():
     assert srf.header == srf_imported.header
 
 
+def test_surfio_can_export_values_in_fortran_order():
+    srf = surfio.IrapSurface(
+        surfio.IrapHeader(ncol=3, nrow=2, xinc=1.0, yinc=1.0, xmax=8.0, ymax=8.0),
+        values=np.asfortranarray(np.arange(6, dtype=np.float32).reshape((3, 2))),
+    )
+    buffer = srf.export_binary()
+    srf_imported = surfio.IrapSurface.import_binary(buffer)
+
+    assert np.allclose(srf.values, srf_imported.values)
+    assert srf.header == srf_imported.header
+
+
 def test_xtgeo_can_import_data_exported_from_surfio(tmp_path):
     srf = surfio.IrapSurface(
         surfio.IrapHeader(


### PR DESCRIPTION
Export was incorrect if numpy array was in fortran order
It is now converted to C order if it comes in fortran order