### PR TITLE
Use string_view instead of const string&

### DIFF
--- a/src/lib/include/irap_import.h
+++ b/src/lib/include/irap_import.h
@@ -3,6 +3,7 @@
 #include "irap.h"
 #include <span>
 #include <string>
+#include <string_view>
 
 // convert from Fortran order to C order
 inline size_t column_major_to_row_major_index(size_t idx, size_t nrow, size_t ncol) {
@@ -10,6 +11,6 @@ inline size_t column_major_to_row_major_index(size_t idx, size_t nrow, size_t nc
 }
 
 irap import_irap_ascii(std::string path);
-irap import_irap_ascii_from_string(const std::string& buffer);
+irap import_irap_ascii_from_string(std::string_view buffer);
 irap import_irap_binary(std::string path);
 irap import_irap_binary_from_buffer(std::span<const char> buffer);

--- a/src/lib/irap_import_ascii.cpp
+++ b/src/lib/irap_import_ascii.cpp
@@ -87,8 +87,8 @@ irap import_irap_ascii(std::string path) {
   return {.header = std::move(head), .values = std::move(values)};
 }
 
-irap import_irap_ascii_from_string(const std::string& buffer) {
-  auto buffer_begin = buffer.c_str();
+irap import_irap_ascii_from_string(std::string_view buffer) {
+  auto buffer_begin = buffer.data();
   auto buffer_end = buffer_begin + buffer.size();
   auto [head, ptr] = get_header(buffer_begin, buffer_end);
   auto values = get_values(ptr, buffer_end, head.ncol, head.nrow);

--- a/src/pybind_module/surfio.cpp
+++ b/src/pybind_module/surfio.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl/filesystem.h>
+#include <string_view>
 
 namespace py = pybind11;
 
@@ -84,7 +85,7 @@ PYBIND11_MODULE(surfio, m) {
       )
       .def_static(
           "import_ascii",
-          [](const std::string& string) -> irap_python* {
+          [](std::string_view string) -> irap_python* {
             auto irap = import_irap_ascii_from_string(string);
             // lock the GIL before creating the numpy array
             py::gil_scoped_acquire acquire;


### PR DESCRIPTION
string_view is generally preferred to const string& as it also allows for c string style strings