### PR TITLE
Split release and pull request workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   build:
     name: Python ${{ inputs.python-version }} on ${{ inputs.os }}-${{ inputs.arch }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Build & Publish
 
 on:
-  pull_request:
-  release:
-    types: [published]
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,17 +12,6 @@ jobs:
     name: Python ${{ matrix.python[0] }} on ${{ matrix.os_arch[0] }}-${{ matrix.os_arch[1] }}
     runs-on: ${{ matrix.os_arch[0] }}
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        python:
-          - ["3.11", cp311]
-          # - ["3.12", cp312]
-        os_arch:
-          - [ubuntu-latest, manylinux_x86_64]
-          - [windows-latest, win_amd64]
-          # - [macos-13, macosx_x86_64] # macos-13 is the last x86-64 runner
-          - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
     env:
       CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.os_arch[1] }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,19 @@ name: Build & Publish
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      python-shortname:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -9,11 +22,11 @@ concurrency:
 
 jobs:
   build:
-    name: Python ${{ inputs.python[0] }} on ${{ inputs.os_arch[0] }}-${{ inputs.os_arch[1] }}
-    runs-on: ${{ inputs.os_arch[0] }}
+    name: Python ${{ inputs.python-version }} on ${{ inputs.os }}-${{ inputs.arch }}
+    runs-on: ${{ inputs.os }}
     timeout-minutes: 15
     env:
-      CIBW_BUILD: ${{ inputs.python[1] }}-${{ inputs.os_arch[1] }}
+      CIBW_BUILD: ${{ inputs.python-shortname }}-${{ inputs.arch }}
 
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.python[0] }}
+          python-version: ${{ inputs.python-version }}
 
       - name: Set up gcc-14
         if: ${{ contains(runner.os, 'macos') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ concurrency:
 
 jobs:
   build:
-    name: Python ${{ matrix.python[0] }} on ${{ matrix.os_arch[0] }}-${{ matrix.os_arch[1] }}
-    runs-on: ${{ matrix.os_arch[0] }}
+    name: Python ${{ inputs.python[0] }} on ${{ inputs.os_arch[0] }}-${{ inputs.os_arch[1] }}
+    runs-on: ${{ inputs.os_arch[0] }}
     timeout-minutes: 15
     env:
-      CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.os_arch[1] }}
+      CIBW_BUILD: ${{ inputs.python[1] }}-${{ inputs.os_arch[1] }}
 
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python[0] }}
+          python-version: ${{ inputs.python[0] }}
 
       - name: Set up gcc-14
         if: ${{ contains(runner.os, 'macos') }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,10 @@ name: Pull request
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     uses: ./.github/workflows/publish.yml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,3 +15,6 @@ jobs:
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]
           - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
+    with:
+      python: ${{matrix.python}}
+      os_arch: ${{matrix.os_arch}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,17 @@
+name: Pull request
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    uses: ./.github/workflows/publish.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - ["3.11", cp311]
+        os_arch:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [windows-latest, win_amd64]
+          - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,5 +16,7 @@ jobs:
           - [windows-latest, win_amd64]
           - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
     with:
-      python: ${{matrix.python}}
-      os_arch: ${{matrix.os_arch}}
+      python-version: ${{matrix.python[0]}}
+      python-shortname: ${{matrix.python[1]}}
+      os: ${{matrix.os_arch[0]}}
+      arch: ${{matrix.os_arch[1]}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,6 @@ jobs:
           - [windows-latest, win_amd64]
           - [macos-13, macosx_x86_64] # macos-13 is the last x86-64 runner
           - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
+    with:
+      python: ${{matrix.python}}
+      os_arch: ${{matrix.os_arch}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     uses: ./.github/workflows/publish.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    uses: ./.github/workflows/publish.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - ["3.11", cp311]
+          - ["3.12", cp312]
+          - ["3.13", cp313]
+        os_arch:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [windows-latest, win_amd64]
+          - [macos-13, macosx_x86_64] # macos-13 is the last x86-64 runner
+          - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,7 @@ jobs:
           - [macos-13, macosx_x86_64] # macos-13 is the last x86-64 runner
           - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
     with:
-      python: ${{matrix.python}}
-      os_arch: ${{matrix.os_arch}}
+      python-version: ${{matrix.python[0]}}
+      python-shortname: ${{matrix.python[1]}}
+      os: ${{matrix.os_arch[0]}}
+      arch: ${{matrix.os_arch[1]}}


### PR DESCRIPTION
This way we can make a lot more wheels without running a ton of builds on each PR