### PR TITLE
Fix mask for binary files

### DIFF
--- a/src/lib/include/irap.h
+++ b/src/lib/include/irap.h
@@ -4,9 +4,11 @@
 #include <vector>
 
 namespace surfio::irap {
-constexpr float UNDEF_MAP_IRAP = 9999900.0000;
+constexpr float UNDEF_MAP_IRAP_ASCII = 9999900.0000;
+constexpr float UNDEF_MAP_IRAP_BINARY = 1e30;
 
 struct irap_header {
+  // All irap headers start with -996
   static constexpr int id = -996;
   int ncol;
   int nrow;

--- a/src/lib/irap_export_ascii.cpp
+++ b/src/lib/irap_export_ascii.cpp
@@ -11,9 +11,8 @@
 namespace fs = std::filesystem;
 
 namespace surfio::irap {
-// All irap headers start with -996
 static const auto id = std::format("{} ", irap_header::id);
-static auto UNDEF_MAP_IRAP_STRING = std::format("{:f}", UNDEF_MAP_IRAP);
+static auto UNDEF_MAP_IRAP_STRING = std::format("{:f}", UNDEF_MAP_IRAP_ASCII);
 
 void write_header_ascii(const irap_header& header, std::ostream& out) {
   out << std::setprecision(6) << std::fixed << std::showpoint;

--- a/src/lib/irap_export_binary.cpp
+++ b/src/lib/irap_export_binary.cpp
@@ -57,7 +57,7 @@ void write_values_binary(surf_span values, std::ostream& out) {
       }
 
       auto v = values(i, j);
-      write_32bit_binary_value(bufptr, std::isnan(v) ? UNDEF_MAP_IRAP : v);
+      write_32bit_binary_value(bufptr, std::isnan(v) ? UNDEF_MAP_IRAP_BINARY : v);
 
       if (++written_on_line == chunk_length) {
         write_32bit_binary_value(bufptr, chunk_length * 4);

--- a/src/lib/irap_import_ascii.cpp
+++ b/src/lib/irap_import_ascii.cpp
@@ -72,7 +72,7 @@ std::vector<float> get_values(const char* start, const char* end, int ncol, int 
     if (result.ec != std::errc())
       throw std::domain_error("Failed to read values during Irap ASCII import.");
 
-    if (value == UNDEF_MAP_IRAP)
+    if (value >= UNDEF_MAP_IRAP_ASCII)
       value = std::numeric_limits<float>::quiet_NaN();
 
     auto ic = column_major_to_row_major_index(i, ncol, nrow);

--- a/src/lib/irap_import_binary.cpp
+++ b/src/lib/irap_import_binary.cpp
@@ -99,7 +99,7 @@ std::vector<float> get_values_binary(const char* start, const char* end, int nco
       float value;
       ptr = read_32bit_value(ptr, end, value);
       auto ic = column_major_to_row_major_index(i, ncol, nrow);
-      values[ic] = value;
+      values[ic] = value < UNDEF_MAP_IRAP_BINARY ? value : std::numeric_limits<float>::quiet_NaN();
     }
     ptr = read_and_check_value(ptr, end, chunk_size, "Block size mismatch");
   }

--- a/tests/python_module/test_irap_binary.py
+++ b/tests/python_module/test_irap_binary.py
@@ -87,11 +87,11 @@ def test_xtgeo_can_import_data_exported_from_surfio(tmp_path):
     compare_xtgeo_surface_with_surfio_header(srf_imported, srf.header)
 
 
-def test_exporting_nan_maps_to_9999900():
+def test_exporting_nan() -> None:
     surface = surfio.IrapSurface(
         surfio.IrapHeader(ncol=1, nrow=1, xinc=2.0, yinc=2.0, xmax=2.0, ymax=2.0),
         values=np.array([[np.nan]], dtype=np.float32),
     )
 
     srf_export = surface.to_binary_buffer()
-    assert struct.unpack("f", srf_export[107:103:-1]) == (9999900.0,)
+    assert struct.unpack("f", srf_export[107:103:-1])[0] >= 1e30


### PR DESCRIPTION
Irap binary uses a different magic number when "masking" unused numbers