### PR TITLE
Avoid floating point overload of std::from_chars

### DIFF
--- a/src/lib/irap_import_ascii.cpp
+++ b/src/lib/irap_import_ascii.cpp
@@ -5,6 +5,9 @@
 #include <filesystem>
 #include <format>
 
+#include <errno.h>
+#include <stdlib.h>
+
 namespace fs = std::filesystem;
 
 namespace surfio::irap {
@@ -15,14 +18,32 @@ auto is_space = [](char ch) { return facet.is(std::ctype_base::space, ch); };
 template <typename T, typename... U>
 const char* read_headers(const char* start, const char* end, T& arg, U&... args) {
   start = std::find_if_not(start, end, is_space);
-  auto [ptr, ec] = std::from_chars(start, end, arg);
-  if (ec != std::errc{})
-    throw std::domain_error("Failed to read irap headers");
+
+  if constexpr (std::is_floating_point_v<T>) {
+    char* ptr = nullptr;
+    if constexpr (std::is_same_v<T, float>)
+      arg = std::strtof(start, &ptr);
+    else if constexpr (std::is_same_v<T, double>)
+      arg = std::strtod(start, &ptr);
+    else if constexpr (std::is_same_v<T, long double>)
+      arg = std::strtold(start, &ptr);
+    else
+      throw std::domain_error("Unsupported floating point type in irap headers");
+
+    if (errno != 0 || ptr == start || ptr > end)
+        throw std::domain_error("Failed to read float in irap headers");
+    start = ptr;
+  } else {
+    auto [ptr, ec] = std::from_chars(start, end, arg);
+    if (ec != std::errc{})
+        throw std::domain_error("Failed to read int in irap headers");
+    start = ptr;
+  }
 
   if constexpr (sizeof...(args) > 0)
-    ptr = read_headers(ptr, end, args...);
+    start = read_headers(start, end, args...);
 
-  return ptr;
+  return start;
 }
 
 std::tuple<irap_header, const char*> get_header(const char* start, const char* end) {
@@ -67,10 +88,10 @@ std::vector<float> get_values(const char* start, const char* end, int ncol, int 
           )
       );
 
-    auto result = std::from_chars(start, end, value);
-    start = result.ptr;
-    if (result.ec != std::errc())
-      throw std::domain_error("Failed to read values during Irap ASCII import.");
+    char* ptr = nullptr;
+    value = std::strtof(start, &ptr);
+    if (errno != 0 || ptr == start || ptr > end)
+        throw std::domain_error("Failed to read float in irap headers");
 
     if (value >= UNDEF_MAP_IRAP_ASCII)
       value = std::numeric_limits<float>::quiet_NaN();


### PR DESCRIPTION
Apple clang does not provide std::from_char for floating points. So as an alternative, we use std::strdo[f|d|ld].

See #53 