### PR TITLE
Stop building x86_64 wheels for macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         os_arch:
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]
-          - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
+          - [macos-latest, macosx_arm64]
     env:
       CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.os_arch[1] }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,7 @@ jobs:
         os_arch:
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]
-          - [macos-13, macosx_x86_64] # macos-13 is the last cheap x86-64 runner
-          - [macos-latest, macosx_arm64] # macos-latest is always arm64 going forward
+          - [macos-latest, macosx_arm64]
     env:
       CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.os_arch[1] }}
 
@@ -47,11 +46,7 @@ jobs:
           echo "LD=ld" >> $GITHUB_ENV
           echo "AR=gcc-ar-14" >> $GITHUB_ENV
           echo "RANLIB=gcc-ranlib-14" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
-
-      - name: Configure compiler vars [macos/arm]
-        if: ${{ contains(runner.arch, 'ARM64') }}
-        run: echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
 
       - name: Install cibuildwheel
         run: python -m pip install -U pip wheel cibuildwheel twine


### PR DESCRIPTION
Github is retiring macos-13 runners next month. There is no support for x86_64 in macos-14 runners.