### PR TITLE
Copy Python DLL for Windows test discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,17 @@ target_link_libraries(tests PRIVATE Catch2::Catch2WithMain surfio_lib)
 if(TARGET Python::Python)
   target_sources(tests PRIVATE ${SRC_PATH}/test_irap_header.cpp)
   target_link_libraries(tests PRIVATE pybind11::embed)
+  if(WIN32)
+    # Ensure the Python runtime DLL is next to the test executable so that Catch2's
+    # catch_discover_tests (which runs the executable at build time to enumerate tests)
+    # can find it, regardless of whether it happens to be on PATH.
+    add_custom_command(
+      TARGET tests
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Python::Python>"
+              "$<TARGET_FILE_DIR:tests>"
+    )
+  endif()
 endif()
 include(CTest)
 include(Catch)


### PR DESCRIPTION
Copy the Python runtime DLL next to the test executable as a post-build step on Windows so discovery no longer depends on PATH contents. We observed issues with the DLL missing in some cases wheel building the Python wheels via cibuildwheel which fails the publication workflow.

This should fix the [failing publication workflow on Windows with Python 3.13](https://github.com/equinor/surfio/actions/runs/31776954265/job/94697799589).

Tested successfully on my fork, see [workflow run](https://github.com/ajaust/surfio/actions/runs/31779572915/job/94702182628?pr=1).